### PR TITLE
Update build.ps1 to suppress console windows if shim

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ Remove-Item "$build\*" -Recurse -Force | Out-Null
 
 # Build
 Write-Output 'Compiling shim.cs ...'
-& "$PSScriptRoot\packages\Microsoft.Net.Compilers\tools\csc.exe" /deterministic /platform:anycpu /nologo /optimize /target:exe /out:"$build\shim.exe" "$src\shim.cs"
+& "$PSScriptRoot\packages\Microsoft.Net.Compilers\tools\csc.exe" /deterministic /platform:anycpu /nologo /optimize /target:winexe /out:"$build\shim.exe" "$src\shim.cs"
 
 # Checksums
 Write-Output 'Computing checksums ...'


### PR DESCRIPTION
Current behaviour is that shim exe will have its own console window and spawn another window of the target applictaion. This changes the behaviour to suppress the window of the shim.